### PR TITLE
Migrate to WaniKani API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ To get started, install the extension, and go to the options page. Add your publ
 
 Navigate to your favorite webpages, hit the Crabigator and read as normal. As you read you'll come across kanji characters you should know. Do you remember what the mean? How to pronounce them?
 
-##Features
+## Features
 ### Importing Google Spreadsheet Data
 - User can now import large amounts of vocab words using google spreadsheets.
 - This allows users to share their vocab lists.
 - Importing from Google Spreadsheets overrides the WaniKani vocab.
 - Shows the total number of entries that have been imported. Which could be multiple synonyms.
 
-###Custom Vocab Override
+### Custom Vocab Override
 - User can now override WaniKani vocab entries AND "Google spreadsheets import" using the custom vocab box.
 - Or if they just want to add a few extra vocab words easily, they can also use it for that too.
 - This is meant as a quick and dirty way to add your own custom vocab easily without setting up a google spreadsheet.
 - For example, "times" gets translated as "〜回" from WaniKani, which is silly. So you can use this to override it to just "回" if you want.
 - This is not meant for large amounts of vocab since it is also synced using Google Sync.
 
-###Google Chrome Sync
+### Google Chrome Sync
 - Settings for wanikanify now are persistence across computers if user has Chrome's sync functionality enabled.
 - Note the vocab data is not synced because it's too much data. But the settings are synced, so you'll just have to click the "import" buttons again for Google Spreadsheets.
 
-###Audio
+### Audio
 - Mousing over (or clicking) a word will play the audio for that word from HTML5's built-in speech synthesis.
 - This works very well as a learning tool in combination with rikaikun.
 - It's possible the audio played could not be correct if the readings are missing from the spreadsheets, but it will try to play it anyways.
@@ -43,3 +43,4 @@ Navigate to your favorite webpages, hit the Crabigator and read as normal. As yo
 
 * Michael Magill
 * Todd Seiler
+* Christopher Mühl

--- a/options.html
+++ b/options.html
@@ -63,10 +63,10 @@
           <tbody>
             <tr>
               <td>
-                <h4>Public API Key</h4>
+                <h4>API Key</h4>
                 <p>
-                  Your public API key can be found on your <a href="https://www.wanikani.com/account" target="_blank">account</a> page
-                  at WaniKani. Your API key is only used to access your vocabulary list.
+                  You can generate a new API key on the <a href="https://www.wanikani.com/settings/personal_access_tokens" target="_blank">API Tokens</a> section of your
+                  WaniKani profile. Your API key is only used to access your vocabulary list.
                 </p>
               </td>
               <td></td>


### PR DESCRIPTION
[API v1 will cease to exist on September 1](https://community.wanikani.com/t/api-version-2-moving-out-of-beta-sunsetting-api-version-1/42539). Therefore Wanikanify needs to migrate to v2 in order to keep functioning from that date on.

The endpoints in v2 are more atomic in nature, so unfortunately it's not quite as easy to use as v1 but I tried to make the code as readable as possible.

1. We fetch the user's vocabulary assignments. This gives us the user's progress (i.e. SRS level) for each item, but doesn't provide the vocab itself.
2. We fetch the study material. These are all the custom notes and synonyms the user has added to their vocabs.
3. Of the data we have requested this far, we are only interested in the user defined synonyms, the SRS level and the assignment's subject IDs. Therefore we create a simple hash that only includes those values.
4. Request the subject for each of the user's assignments. This gives us the actual list of characters and meanings.